### PR TITLE
Fix production deployments not rebuilding

### DIFF
--- a/deploy/scripts/deploy_prod.sh
+++ b/deploy/scripts/deploy_prod.sh
@@ -17,4 +17,4 @@ sudo touch /opt/traefik/acme.json && sudo chmod 600 /opt/traefik/acme.json
 
 # This will rebuild our serivces *then* replace the current ones with them.
 # Avoiding downtime is cool
-sudo docker-compose -f ~/backend/deploy/docker-compose.default.yml -f ~/backend/deploy/docker-compose.prod.yml up -d --build
+sudo docker-compose -f ~/backend/deploy/docker-compose.default.yml -f ~/backend/deploy/docker-compose.prod.yml up -d --build --force-recreate


### PR DESCRIPTION
Adds `--force-recreate` flag to production deployment script.

From `$ docker-compose up --help`:

```
    --force-recreate           Recreate containers even if their configuration
                               and image haven't changed.
```