### PR TITLE
Catch 404s from traefik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,6 @@ JWT_SIGNING_KEY=
 # Name of cookie that holds the JWT
 JWT_COOKIE_NAME=
 
-# Login used to access traefik's dashboard
-# `$ htpasswd` is helpful for this
-TRAEFIK_DASHBOARD_LOGIN=
 # Used by let's encrypt/acme
 TRAEFIK_EMAIL=
 

--- a/deploy/docker-compose.default.yml
+++ b/deploy/docker-compose.default.yml
@@ -17,7 +17,9 @@ services:
     labels:
       - traefik.enable=true
       # Request locations to route to backend app
-      - traefik.frontend.rule=Host:www.${DOMAIN},${DOMAIN} 
+      # Only take URLs not consumed else where
+      - traefik.frontend.rule=HostRegexp:{catchall:.*}
+      - traefik.frontend.priority=1
       # Name of backend to handle requests from above
       - traefik.backend=bm-app
       - traefik.port=8080
@@ -51,7 +53,3 @@ services:
     labels:
       - traefik.enable=true
       - traefik.port=8080
-      # Request locations to route to dashboard
-      - traefik.frontend.rule=Host:dashboard.${DOMAIN} 
-      # Login for dashboard
-      - traefik.frontend.auth.basic.users=${TRAEFIK_DASHBOARD_LOGIN} 

--- a/deploy/test/.env
+++ b/deploy/test/.env
@@ -34,9 +34,6 @@ JWT_SIGNING_KEY=oh wow oh gosh
 # Name of cookie that holds the JWT
 JWT_COOKIE_NAME=X-BM-Testing-Token
 
-# Login used to access traefik's dashboard
-# `$ htpasswd` is helpful for this
-TRAEFIK_DASHBOARD_LOGIN=a:$apr1$5Jpn1GaL$kLeAGcEIaiRVx6/kj6Pio1
 TRAEFIK_EMAIL=test@boilermake.org
 
 MAILGUN_ADDRESS=

--- a/deploy/traefik/traefik.dev.toml
+++ b/deploy/traefik/traefik.dev.toml
@@ -8,10 +8,6 @@ defaultEntryPoints = ["http"]
   [entryPoints.http]
   address = ":80"
 
-# Enable dashboard that has some neat stats
-[api]
-dashboard = true
-
 # Reload on config changes
 [file]
 watch = true

--- a/deploy/traefik/traefik.prod.toml
+++ b/deploy/traefik/traefik.prod.toml
@@ -14,10 +14,6 @@ defaultEntryPoints = ["http", "https"]
 	address = ":443"
 	[entryPoints.https.tls]
 
-# Enable dashboard that has some neat stats
-[api]
-dashboard = true
-
 # Use acme to get our SSL certs.  Also requires an email for registration, but
 # that's set in deploy/docker-compose.prod.yml (see command in proxy service).
 [acme]


### PR DESCRIPTION
All domains not captured by other services in docker-compose are sent to our backend instead.