### PR TITLE
Attempt to fix cache issues

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,7 +77,7 @@ function publish() {
 	};
 
 	var publisher = awspublish.create(aws);
-	var headers = {"Cache-Control": "max-age=315360000, no-transform, public"};
+	var headers = {"Cache-Control": "max-age=180, no-transform, public, must-revalidate"};
 
 	gulp
 		.src("web/static/**")


### PR DESCRIPTION
We've had big issues with browsers using a cached boilermake.org even after we invalidate. I'm not sure if this header change will make a difference but I'm not sure what else could be the cause