### PR TITLE
Always use lower case emails

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -88,6 +88,7 @@ func (u *User) SetSession(session *sessions.Session) {
 // struct.
 func (u *User) FromFormData(r *http.Request) {
 	u.Email = r.FormValue("email")
+	u.Email = strings.ToLower(u.Email)
 
 	u.Password = r.FormValue("password")
 	u.PasswordConfirm = r.FormValue("password-confirm")

--- a/internal/postgres/user_service.go
+++ b/internal/postgres/user_service.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"crypto/rand"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/BoilerMake/bm-app/internal/models"
@@ -187,6 +188,7 @@ func (s *UserService) GetById(id int) (u *models.User, err error) {
 
 // GetByEmail returns a single user with the given email.
 func (s *UserService) GetByEmail(email string) (u *models.User, err error) {
+	email = strings.ToLower(email)
 	var dbu dbUser
 
 	tx, err := s.DB.Begin()
@@ -267,6 +269,8 @@ func (s *UserService) Update(u *models.User) error {
 		return err
 	}
 
+	u.Email = strings.ToLower(u.Email)
+
 	_, err = tx.Exec(`UPDATE users
 	SET
 		role = $1,
@@ -319,6 +323,8 @@ func (s *UserService) Update(u *models.User) error {
 
 // Creates the user's token for a password reset
 func (s *UserService) GetPasswordReset(email string) (string, error) {
+	email = strings.ToLower(email)
+
 	if email == "" {
 		return "", models.ErrEmptyEmail
 	}


### PR DESCRIPTION
Emails should always be made case insensitive, before this change logging in would say invalid email if you made a letter uppercase.