### PR TITLE
Change rsvp deadline date and include message about limited swag

### DIFF
--- a/internal/models/rsvp.go
+++ b/internal/models/rsvp.go
@@ -13,7 +13,7 @@ var (
 )
 
 const RSVPExpiryTime = 3 * 24 * time.Hour
-var RSVPExpiryDate = time.Date(2020, time.December, 18, 23, 59, 59, 0, time.UTC)
+var RSVPExpiryDate = time.Date(2021, time.January, 25, 23, 59, 59, 0, time.UTC)
 
 type RSVP struct {
 	ID     int

--- a/templates/web/pages/dashboard.tmpl
+++ b/templates/web/pages/dashboard.tmpl
@@ -80,7 +80,7 @@
             </div>
             <p>Congratulations! We are honored to invite you to BoilerMake VIII on January 22nd.
 							Get ready to hack your own adventure and learn new skills while enjoying tech talks, workshops, and online activities on the side.</p>
-						<p><strong>Please RSVP below to let us know if you can make it. Your acceptance will expire on December 18th.</strong></p>
+						<p><strong>Please RSVP below to let us know if you can make it.</strong></p>
             {{ end }}
           {{ end }}
         </div>

--- a/templates/web/pages/rsvp.tmpl
+++ b/templates/web/pages/rsvp.tmpl
@@ -121,6 +121,7 @@
 
             <h4>Your Shipping Address (for swag!)</h4>
             <h6>*We can only ship within the US</h6>
+            <h6>*RSVPs after 12/18 will not guarantee swag</h6>
             <div class="field is-horizontal">
               <div class="field-label is-normal">
                 <label for="accommodations" class="label">Street Address</label>


### PR DESCRIPTION
RSVP deadline is now extended to the end of the event. Swag is limited for those who rsvp after 12/18